### PR TITLE
feat(db): create topics table with Flyway

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+spring.application.name=foro-hub
+server.port=8084
+
+spring.datasource.url=jdbc:mysql://localhost:3306/forohub?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=root
+spring.datasource.password=BosqueVerde#2
+
+# JPA: no auto-crear, solo validar contra el schema de Flyway
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+server.error.include-stacktrace=never

--- a/src/main/resources/db/migration/V1__create_topics_table.sql
+++ b/src/main/resources/db/migration/V1__create_topics_table.sql
@@ -1,0 +1,17 @@
+-- V1__create_topics_table.sql
+-- Minimal topics table
+
+CREATE TABLE IF NOT EXISTS topics (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title VARCHAR(200) NOT NULL,
+  message TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  status VARCHAR(20) NOT NULL,
+  author VARCHAR(100) NOT NULL,
+  course VARCHAR(100) NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_topics_status (status),
+  KEY idx_topics_created_at (created_at)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## What
Adds Flyway V1 migration to create the `topics` table and configures JPA to validate the schema.

## Why
Start the project with versioned DB schema and avoid Hibernate auto-creating tables.

## How
- Flyway V1: topics(id, title, message, created_at, status, author, course)
- application.properties: point to `forohub`, set `ddl-auto=validate`

## How to test
- Start the app
- In MySQL: `USE forohub; SHOW TABLES; DESCRIBE topics;`
- Check `flyway_schema_history` has version 1 applied